### PR TITLE
Fix KeepoutFilter on the ARM architecture

### DIFF
--- a/nav2_costmap_2d/plugins/costmap_filters/costmap_filter.cpp
+++ b/nav2_costmap_2d/plugins/costmap_filters/costmap_filter.cpp
@@ -222,7 +222,7 @@ unsigned char CostmapFilter::getMaskCost(
 {
   const unsigned int index = my * filter_mask->info.width + mx;
 
-  const char data = filter_mask->data[index];
+  const signed char data = filter_mask->data[index];
   if (data == nav2_util::OCC_GRID_UNKNOWN) {
     return NO_INFORMATION;
   } else {


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Proprietary |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Fixed a bug with KeepoutFilter on robots using ARM-based computers
  * ARM by default considers `char` type as **unsigned** as described [here](https://developer.arm.com/documentation/den0013/0400/Porting/Miscellaneous-C-porting/unsigned-char-and-signed-char?lang=en)
  * Simply using a `char` instead of `signed char` when reading the data from `nav_msgs::msg::OccupancyGrid` results in misinterpretation of `-1` values  representing UNKNOWN cells in the filter mask.

## Description of documentation updates required from your changes

N/A

## Description of how this change was tested
Keepout filter was tested on a robot using an ARM-based computer.

---

## Future work that may be required in bullet points

N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
