### PR TITLE
Publish `is_active` status from LifecycleManager

### DIFF
--- a/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
+++ b/nav2_lifecycle_manager/include/nav2_lifecycle_manager/lifecycle_manager.hpp
@@ -25,8 +25,10 @@
 
 #include "nav2_util/lifecycle_service_client.hpp"
 #include "nav2_ros_common/node_thread.hpp"
+#include "nav2_ros_common/publisher.hpp"
 #include "nav2_ros_common/service_server.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/bool.hpp"
 #include "std_srvs/srv/empty.hpp"
 #include "nav2_msgs/srv/manage_lifecycle_nodes.hpp"
 #include "std_srvs/srv/trigger.hpp"
@@ -78,6 +80,10 @@ protected:
   // The services provided by this node
   nav2::ServiceServer<ManageLifecycleNodes>::SharedPtr manager_srv_;
   nav2::ServiceServer<std_srvs::srv::Trigger>::SharedPtr is_active_srv_;
+
+  // Latched publisher for is_active status
+  nav2::Publisher<std_msgs::msg::Bool>::SharedPtr is_active_pub_;
+
   /**
    * @brief Lifecycle node manager callback function
    * @param request_header Header of the service request
@@ -156,6 +162,12 @@ protected:
    */
   void createLifecycleServiceServers();
 
+  // Support function for creating publishers
+  /**
+   * @brief Support function for creating publishers
+   */
+  void createLifecyclePublishers();
+
   // Support functions for shutdown
   /**
    * @brief Support function for shutdown
@@ -165,6 +177,10 @@ protected:
    * @brief Destroy all the lifecycle service clients.
    */
   void destroyLifecycleServiceClients();
+  /**
+   * @brief Destroy all the lifecycle publishers.
+   */
+  void destroyLifecyclePublishers();
 
   // Support function for creating bond timer
   /**
@@ -231,9 +247,19 @@ protected:
   void registerRclPreshutdownCallback();
 
   /**
+   * @brief Set the state of managed nodes
+   */
+  void setState(const NodeState & state);
+
+  /**
    * @brief function to check if managed nodes are active
    */
   bool isActive();
+
+  /**
+   * @brief Publish the is_active state
+   */
+  void publishIsActiveState();
 
   // Timer thread to look at bond connections
   rclcpp::TimerBase::SharedPtr init_timer_;

--- a/nav2_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/nav2_lifecycle_manager/src/lifecycle_manager.cpp
@@ -160,9 +160,9 @@ void
 LifecycleManager::publishIsActiveState()
 {
   if (is_active_pub_ && is_active_pub_->is_activated()) {
-    auto message = std_msgs::msg::Bool();
-    message.data = isActive();
-    is_active_pub_->publish(message);
+    auto message = std::make_unique<std_msgs::msg::Bool>();
+    message->data = isActive();
+    is_active_pub_->publish(std::move(message));
   }
 }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | Simulation |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

This PR adds the feature to publish (on a latched topic) the `is_active` status message from the `LifecycleManager`.

## Description of documentation updates required from your changes

N/A

## Description of how this change was tested

Tested the feature in simulation the following scenarios:
1. With `autostart` set to false, `is_active = False` is published once on startup
    1.  On calling the `manage_nodes` srv with `command = STARTUP`, `is_active = True` is published once when all the nodes are in active state
    2. When transitioning to another state using `manage_nodes` srv, `is_active = False` is published
2. With `autostart` set to true, `is_active = False` is published at LifecycleManager node startup. When all the nodes transition to active state,  `is_active = True` is published once.

---

## Future work that may be required in bullet points

N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
