### PR TITLE
Refactor/bt test util classes

### DIFF
--- a/nav2_behavior_tree/test/utils/test_behavior_tree_fixture.hpp
+++ b/nav2_behavior_tree/test/utils/test_behavior_tree_fixture.hpp
@@ -70,7 +70,9 @@ public:
 
   static void TearDownTestCase()
   {
-    transform_handler_->deactivate();
+    if (transform_handler_ && transform_handler_->isActive()) {
+      transform_handler_->deactivate();
+    }
 
     // Properly deactivate and cleanup the lifecycle node
     node_->deactivate();

--- a/nav2_behavior_tree/test/utils/test_transform_handler.hpp
+++ b/nav2_behavior_tree/test/utils/test_transform_handler.hpp
@@ -56,6 +56,8 @@ public:
     if (is_active_) {
       deactivate();
     }
+    tf_listener_.reset();
+    tf_buffer_.reset();
   }
 
   // Activate the tester before running tests
@@ -88,8 +90,6 @@ public:
 
     spin_thread_.reset();
     tf_broadcaster_.reset();
-    tf_buffer_.reset();
-    tf_listener_.reset();
   }
 
   std::shared_ptr<tf2_ros::Buffer> getBuffer() const

--- a/nav2_behavior_tree/test/utils/test_transform_handler.hpp
+++ b/nav2_behavior_tree/test/utils/test_transform_handler.hpp
@@ -51,7 +51,7 @@ public:
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
   }
 
-  ~TransformHandler()
+  virtual ~TransformHandler()
   {
     if (is_active_) {
       deactivate();
@@ -59,7 +59,7 @@ public:
   }
 
   // Activate the tester before running tests
-  void activate()
+  virtual void activate(std::chrono::milliseconds tf_broadcast_period = 100ms)
   {
     if (is_active_) {
       throw std::runtime_error("Trying to activate while already active");
@@ -69,39 +69,47 @@ public:
     // Launch a thread to process the messages for this node
     spin_thread_ = std::make_unique<nav2::NodeThread>(node_->get_node_base_interface());
 
-    startRobotTransform();
+    if (tf_broadcast_period.count() > 0) {
+      startRobotTransform(tf_broadcast_period);
+    }
   }
 
-  void deactivate()
+  virtual void deactivate()
   {
     if (!is_active_) {
       throw std::runtime_error("Trying to deactivate while already inactive");
     }
     is_active_ = false;
+
+    if (transform_timer_) {
+      transform_timer_->cancel();
+      transform_timer_.reset();
+    }
+
     spin_thread_.reset();
     tf_broadcaster_.reset();
     tf_buffer_.reset();
     tf_listener_.reset();
   }
 
-  std::shared_ptr<tf2_ros::Buffer> getBuffer()
+  std::shared_ptr<tf2_ros::Buffer> getBuffer() const
   {
     return tf_buffer_;
   }
 
-  void waitForTransform()
+  virtual void waitForTransform() const
   {
     if (is_active_) {
       while (!tf_buffer_->canTransform("map", "base_link", rclcpp::Time(0))) {
         std::this_thread::sleep_for(100ms);
       }
       RCLCPP_INFO(node_->get_logger(), "Transforms are available now!");
-      return;
+    } else {
+      throw std::runtime_error("Trying to wait for transform while inactive!");
     }
-    throw std::runtime_error("Trying to deactivate while already inactive");
   }
 
-  void updateRobotPose(const geometry_msgs::msg::Pose & pose)
+  virtual void updateRobotPose(const geometry_msgs::msg::Pose & pose)
   {
     // Update base transform to publish
     base_transform_->transform.translation.x = pose.position.x;
@@ -114,14 +122,16 @@ public:
     publishRobotTransform();
   }
 
-private:
+  bool isActive() const {return is_active_;}
+
+protected:
   void publishRobotTransform()
   {
     base_transform_->header.stamp = node_->now();
     tf_broadcaster_->sendTransform(*base_transform_);
   }
 
-  void startRobotTransform()
+  virtual void startRobotTransform(std::chrono::milliseconds tf_broadcast_period)
   {
     // Provide the robot pose transform
     tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(node_);
@@ -141,7 +151,7 @@ private:
 
     // Publish the transform periodically
     transform_timer_ = node_->create_wall_timer(
-      100ms, std::bind(&TransformHandler::publishRobotTransform, this));
+      tf_broadcast_period, std::bind(&TransformHandler::publishRobotTransform, this));
   }
 
   nav2::LifecycleNode::SharedPtr node_;


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | N/A |
| Does this PR contain AI generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

* Refactored the unit-test utility classes in nav2_behavior_tree pkg
* This allows extending the `TransformHandler` class to customize its behavior based on the use-case
* It is now also possible to use the `TransformHandler` only to listen on TF data and not to broadcast the `map_T_base_link` transform.
* It is now also possible to control the rate at which the `map_T_base_link` transforms are broadcasted by the `TransformHandler`.
* Prevents deleting the `tf_buffer_` and `tf_listener_` on calling `deactivate` of the `TransformHandler`. Instead we now only clear the buffer on deactivation. This ensures that the pointer to the buffer on the blackboard stays valid through the entirety of the test suite.
* Added a new method to check if the the `TransformHandler` is in active state.

## Description of documentation updates required from your changes

N/A

## Description of how this change was tested

Ensured that all the existing unit tests are running successfully

---

## Future work that may be required in bullet points

N/A

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
